### PR TITLE
Changes to make Interpreter accept CommandBase as constructor argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,8 @@ file(GLOB SOURCE ${PROJECT_SOURCE_DIR}/src/*.cpp
 
 add_library(command_base SHARED ${PROJECT_SOURCE_DIR}/src/commands/CommandBase.h
         ${PROJECT_SOURCE_DIR}/src/commands/CommandBase.cpp
-        ${PROJECT_SOURCE_DIR}/src/commands/CommandResponse.h)
+        ${PROJECT_SOURCE_DIR}/src/commands/CommandResponse.h
+        ${PROJECT_SOURCE_DIR}/src/commands/ModelSpecification.h)
 
 target_link_libraries(command_base ${PROJECT_SOURCE_DIR}/libs/libz3.so)
 target_link_libraries(command_base ${PROJECT_SOURCE_DIR}/libs/libverification-algorithms.so)

--- a/src/commands/CommandBase.h
+++ b/src/commands/CommandBase.h
@@ -1,101 +1,114 @@
 #pragma once
 
 #include <utility>
+#include <memory>
+#include <StringConstants.h>
 #include <verification-algorithms/common/verifier.hpp>
-#include <verification-algorithms/k-induction/k-induction.hpp>
 #include <verification-algorithms/ltl-bmc/ltl-bmc.hpp>
-#include <complyer/util/Kripke.hpp>
+#include <verification-algorithms/k-induction/k-induction.hpp>
+
+#include "ModelSpecification.h"
 #include "CommandResponse.h"
 
 class CommandBase {
   public:
-    struct CommandBaseSignature {
-      std::vector<Symbol> symbols;
-      Kripke kripke;
-      std::map<std::string,std::string> label_mapper;
-      CommandBaseSignature(std::vector<Symbol> s, Kripke k, std::map<std::string,std::string> labelMapper): symbols(std::move(s)), kripke(std::move(k)), label_mapper(std::move(labelMapper)){}
-    };
-
-    CommandBase(const std::vector<Symbol>& symbols,Kripke kripke,const std::map<std::string,std::string>& labelMapper);
-    explicit CommandBase(const CommandBaseSignature& commandBaseSignature): CommandBase(commandBaseSignature.symbols, commandBaseSignature.kripke, commandBaseSignature.label_mapper){}
-    CommandBase(const CommandBase &commandBase): CommandBase(commandBase.getSignature()) {};
-
-    [[nodiscard]] CommandResponse perform(const std::string &line) const;
-    [[nodiscard]] inline CommandBaseSignature getSignature() const {
-      return signature;
-    }
-
+    explicit CommandBase(ModelSpecification m);
+    CommandResponse perform(const std::string &line);
   private:
-    class CommandInterface {
-      public:
-        CommandInterface(std::string op, std::shared_ptr<ltlBmc> lbv,
-                         std::shared_ptr<kInduction> kiv);
-        virtual void setVerifier(const std::shared_ptr<Verifier> &v){}
-        inline std::string getOperation() { return operation;}
-        virtual inline std::string getMessage(){ return std::__cxx11::string();};
-        virtual bool parse(std::string line) = 0;
-        virtual int perform() = 0;
-      protected:
-        std::shared_ptr<ltlBmc> ltl_bmc_verifier;
-        std::shared_ptr<kInduction> k_induction_verifier;
-        std::shared_ptr<Verifier> common_verifier;
-      private:
-        std::string operation;
-    };
-    class CommandBound : public CommandInterface {
-      public:
-        CommandBound(std::shared_ptr<ltlBmc> lbv, std::shared_ptr<kInduction> kiv);
-        bool parse(std::string line) override;
-        int perform() override;
-      private:
-        int bound;
-    };
-    class CommandLength : public CommandInterface {
-      public:
-        CommandLength(std::shared_ptr<ltlBmc> lbv, std::shared_ptr<kInduction> kiv);
-        void setVerifier(const std::shared_ptr<Verifier> &v) override;
-        bool parse(std::string line) override;
-        int perform() override;
-    };
-    class CommandLtlspec : public CommandInterface {
-      public:
-        CommandLtlspec(std::shared_ptr<ltlBmc> lbv, std::shared_ptr<kInduction> kiv,
-                       std::map<std::string, std::string> labelMapper);
-        bool parse(std::string line) override;
-        int perform() override;
-      private:
-        std::map<std::string, std::string> label_mapper;
-        std::string property;
-    };
-    class CommandQuit : public CommandInterface {
-      public:
-        CommandQuit(std::shared_ptr<ltlBmc> lbv, std::shared_ptr<kInduction> kiv);
-        bool parse(std::string line) override;
-        int perform() override;
-    };
-    class CommandSafetyspec : public CommandInterface {
-      public:
-        CommandSafetyspec(std::shared_ptr<ltlBmc> lbv, std::shared_ptr<kInduction> kiv,
-                          std::map<std::string, std::string> labelMapper);
-        bool parse(std::string line) override;
-        int perform() override;
-      private:
-        std::map<std::string, std::string> label_mapper;
-        std::string property;
-    };
-    class CommandTrace : public CommandInterface {
-      public:
-        CommandTrace(std::shared_ptr<ltlBmc> lbv, std::shared_ptr<kInduction> kiv);
-        void setVerifier(const std::shared_ptr<Verifier> &v) override;
-        bool parse(std::string line) override;
-        int perform() override;
-        std::string getMessage() override;
-    };
+    class CommandInterface;
+    class CommandQuit;
+    class CommandTrace;
+    class CommandLength;
+    class CommandSafetyspec;
+    class CommandBound;
+    class CommandLtlspec;
 
-    CommandBaseSignature signature;
-    std::vector<std::shared_ptr<CommandInterface>> command;
-    enum command_list{BOUND, LENGTH, LTLSPEC, QUIT, SAFETYSPEC, TRACE};
+    struct Commands;
+    struct Verifiers;
 
-    std::shared_ptr<ltlBmc> ltl_bmc_verifier;
+    ModelSpecification model;
+    std::shared_ptr<Commands> command;
+    std::shared_ptr<Verifiers> verifier;
+};
+
+class CommandBase::CommandInterface {
+  public:
+    explicit CommandInterface(std::string op): operation(std::move(op)){};
+    [[nodiscard]] inline std::string getOperation() const { return operation; }
+    virtual bool parse(const std::string &);
+    virtual CommandResponse perform() = 0;
+  private:
+    const std::string operation;
+};
+
+class CommandBase::CommandQuit : public CommandInterface {
+  public:
+    CommandQuit() : CommandInterface(StringConstants::QUIT){};
+    CommandResponse perform() override;
+};
+
+class CommandBase::CommandTrace : public CommandInterface {
+  public:
+    CommandTrace() : CommandInterface(StringConstants::TRACE){ (this->common_verifier) = nullptr; };
+    CommandResponse perform() override;
+    void setVerifier(std::shared_ptr<Verifier>);
+  private:
+    std::shared_ptr<Verifier> common_verifier;
+};
+
+class CommandBase::CommandLength : public CommandInterface {
+  public:
+    CommandLength() : CommandInterface(StringConstants::LENGTH){ (this->common_verifier) = nullptr; };
+    CommandResponse perform() override;
+    void setVerifier(std::shared_ptr<Verifier>);
+  private:
+    std::shared_ptr<Verifier> common_verifier;
+};
+
+class CommandBase::CommandSafetyspec : public CommandInterface {
+  public:
+    CommandSafetyspec(std::shared_ptr<kInduction> kiv, std::map<std::string, std::string> lm): CommandInterface(StringConstants::SAFETYSPEC), k_induction_verifier(std::move(kiv)), label_mapper(std::move(lm)){}
+    bool parse(const std::string &) override;
+    CommandResponse perform() override;
+  private:
     std::shared_ptr<kInduction> k_induction_verifier;
+    std::map<std::string, std::string> label_mapper;
+    std::string property;
+};
+
+class CommandBase::CommandBound : public CommandInterface {
+  public:
+    explicit CommandBound(std::shared_ptr<ltlBmc> lbv): CommandInterface(StringConstants::BOUND), ltl_bmc_verifier(std::move(lbv)){}
+    bool parse(const std::string &) override;
+    CommandResponse perform() override;
+  private:
+    std::shared_ptr<ltlBmc> ltl_bmc_verifier;
+    int bound{};
+};
+
+class CommandBase::CommandLtlspec : public CommandInterface {
+  public:
+    CommandLtlspec(std::shared_ptr<ltlBmc> lbv, std::map<std::string, std::string> lm): CommandInterface(StringConstants::LTLSPEC), ltl_bmc_verifier(std::move(lbv)), label_mapper(std::move(lm)){}
+    bool parse(const std::string &) override;
+    CommandResponse perform() override;
+  private:
+    std::shared_ptr<ltlBmc> ltl_bmc_verifier;
+    std::map<std::string, std::string> label_mapper;
+    std::string property;
+};
+
+struct CommandBase::Verifiers {
+  std::shared_ptr<ltlBmc> ltl_bmc_verifier;
+  std::shared_ptr<kInduction> k_induction_verifier;
+  Verifiers(const std::vector<Symbol>& symbols, Kripke kripke);
+};
+
+struct CommandBase::Commands {
+  std::shared_ptr<CommandQuit> quit;
+  std::shared_ptr<CommandTrace> trace;
+  std::shared_ptr<CommandLength> length;
+  std::shared_ptr<CommandSafetyspec> safetyspec;
+  std::shared_ptr<CommandBound> bound;
+  std::shared_ptr<CommandLtlspec> ltlspec;
+  Commands(const std::shared_ptr<Verifiers> &verifier, const std::map<std::string, std::string>& labelMapper);
 };

--- a/src/commands/CommandResponse.h
+++ b/src/commands/CommandResponse.h
@@ -6,18 +6,10 @@
 class CommandResponse {
   public:
     CommandResponse(std::string operation, int result, std::string message, long timeTaken) : operation(std::move(operation)),result(result),message(std::move(message)),time_taken(timeTaken) {}
-    [[nodiscard]] std::string getOperation() const {
-      return operation;
-    }
-    [[nodiscard]] int getResult() const {
-      return result;
-    }
-    [[nodiscard]] std::string getMessage() const {
-      return message;
-    }
-    [[nodiscard]] long getTimeTaken() const {
-      return time_taken;
-    }
+    inline std::string getOperation() { return operation; }
+    [[nodiscard]] inline int getResult() const { return result; }
+    inline std::string getMessage() { return message; }
+    [[nodiscard]] inline long getTimeTaken() const { return time_taken; }
   private:
     std::string operation;
     int result;

--- a/src/commands/ModelSpecification.h
+++ b/src/commands/ModelSpecification.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <verification-algorithms/common/symbol.hpp>
+#include <utility>
+#include <vector>
+#include <complyer/util/Kripke.hpp>
+#include <map>
+
+class ModelSpecification {
+  public:
+    ModelSpecification()= default;
+    ModelSpecification(std::vector<Symbol> s, Kripke k, std::map<std::string, std::string> lm)
+      : symbols(std::move(s)), kripke(std::move(k)), label_mapper(std::move(lm)){};
+
+    inline void setSymbols(std::vector<Symbol> s){ (this->symbols) = std::move(s); }
+    inline void setKripke(Kripke k){ (this->kripke) = std::move(k); }
+    inline void setLabelMapper(std::map<std::string, std::string> lm){ (this->label_mapper) = std::move(lm);}
+
+    inline std::vector<Symbol> getSymbols(){ return symbols; }
+    inline Kripke getKripke(){ return kripke; }
+    inline std::map<std::string, std::string> getLabelMapper(){ return label_mapper; }
+  private:
+    std::vector<Symbol> symbols;
+    Kripke kripke;
+    std::map<std::string, std::string> label_mapper;
+};

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1,7 +1,6 @@
 #include <fstream>
 #include <interpreter/PrinterFunctions.h>
 #include "./nusmv/NuSMVListener.h"
-#include "complyer/nusmv/NuSMV.hpp"
 #include "interpreter/Interpreter.h"
 #include "InputOptions.h"
 
@@ -19,7 +18,7 @@ class Main {
         printVariables(nusmv);
         printKripke(k);
       }
-      CommandBase commandBase(nusmv.getSymbols(), k, nusmv.getMapping());
+      CommandBase commandBase(ModelSpecification(nusmv.getSymbols(), k, nusmv.getMapping()));
       Interpreter interpreter(commandBase);
       if(inputOptions->isBatch()) interpreter.setPrinter(PrinterFunctions::batch);
       else interpreter.setPrinter(PrinterFunctions::interactive);

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -8,13 +8,13 @@
 
 class Interpreter {
   CommandBase command_base;
-  std::function<void(const CommandResponse&,const CommandBase&)> print_function;
+  std::function<void(CommandResponse, CommandBase)> print_function;
 public:
   explicit Interpreter(CommandBase commandBase): command_base(std::move(commandBase)) {}
-  void setPrinter(std::function<void(const CommandResponse&,const CommandBase&)> printer){
+  inline void setPrinter(std::function<void(CommandResponse, CommandBase)> printer){
     print_function = std::move(printer);
   }
-  void interpret(const std::string& input) {
+  inline void interpret(const std::string& input) {
     CommandResponse command_response = command_base.perform(input);
     print_function(command_response,command_base);
   }

--- a/src/interpreter/PrinterFunctions.h
+++ b/src/interpreter/PrinterFunctions.h
@@ -6,7 +6,7 @@
 #include <NumericConstants.h>
 
 namespace PrinterFunctions {
-  void interactive(const CommandResponse &command_response, const CommandBase &command_base) {
+  void interactive(CommandResponse command_response, CommandBase command_base) {
     if(command_response.getOperation() == StringConstants::QUIT or command_response.getOperation() == StringConstants::BOUND) {}
     else if(command_response.getOperation() == StringConstants::SAFETYSPEC or command_response.getOperation() == StringConstants::LTLSPEC) {
       if(command_response.getResult() == NumericConstants::SAT) {
@@ -25,7 +25,7 @@ namespace PrinterFunctions {
     }
   }
 
-  void batch(const CommandResponse &command_response, const CommandBase &command_base) {
+  void batch(CommandResponse command_response, CommandBase command_base) {
     if(command_response.getOperation() == StringConstants::LTLSPEC or command_response.getOperation() == StringConstants::SAFETYSPEC) {
       CommandResponse length_response = command_base.perform(StringConstants::LENGTH);
       if(command_response.getResult() == NumericConstants::SAT) {


### PR DESCRIPTION
Have some issues wrt CommandBase and am using workarounds for now. Need to discuss this